### PR TITLE
fix: abstract method def, check for None

### DIFF
--- a/bbmri_fp_etl/destinations/fhir.py
+++ b/bbmri_fp_etl/destinations/fhir.py
@@ -377,30 +377,31 @@ class FHIRDest:
             'value': t
         }) for t in record.url] if record.url is not None else None
         contacts = []
-        for c in record.contact:
-            contact = OrganizationContact()
-            if c.role.type == RoleType.HEAD and c.role.description is not None:
-                contact.extension = [Extension({
-                    'url': CONTACT_ROLE_EXTENSION,
-                    'valueString': c.role.description
-                })]
-            contact.purpose = CodeableConcept({
-                'coding': [{
-                    'system': CONTACT_POINT_PURPOSE,
-                    'code': CONTACT_POINT_PURPOSE_ADMIN if c.role.type == RoleType.HEAD else CONTACT_POINT_PURPOSE_RESEARCH
-                }]
-            })
-            contact.name = HumanName({
-                'given': [c.name.given] if c.name is not None else None,
-                'family': c.name.family if c.name is not None else None,
-                'prefix': c.name.prefix if c.name is not None else None,
-                'suffix': c.name.suffix if c.name is not None else None
-            })
-            contact.telecom = [ContactPoint({
-                'system': t.type.value,
-                'value': t.value
-            }) for t in c.telecom]
-            contacts.append(contact)
+        if record.contact:
+            for c in record.contact:
+                contact = OrganizationContact()
+                if c.role.type == RoleType.HEAD and c.role.description is not None:
+                    contact.extension = [Extension({
+                        'url': CONTACT_ROLE_EXTENSION,
+                        'valueString': c.role.description
+                    })]
+                contact.purpose = CodeableConcept({
+                    'coding': [{
+                        'system': CONTACT_POINT_PURPOSE,
+                        'code': CONTACT_POINT_PURPOSE_ADMIN if c.role.type == RoleType.HEAD else CONTACT_POINT_PURPOSE_RESEARCH
+                    }]
+                })
+                contact.name = HumanName({
+                    'given': [c.name.given] if c.name is not None else None,
+                    'family': c.name.family if c.name is not None else None,
+                    'prefix': c.name.prefix if c.name is not None else None,
+                    'suffix': c.name.suffix if c.name is not None else None
+                })
+                contact.telecom = [ContactPoint({
+                    'system': t.type.value,
+                    'value': t.value
+                }) for t in c.telecom]
+                contacts.append(contact)
         resource.contact = contacts
 
         if isinstance(record, Biobank):

--- a/bbmri_fp_etl/sources.py
+++ b/bbmri_fp_etl/sources.py
@@ -2,30 +2,38 @@
 #
 # This file is part of BBMRI-FP-ETL.
 #
-# BBMRI-FP-ETL is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+# BBMRI-FP-ETL is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
 #
-# BBMRI-FP-ETL is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# BBMRI-FP-ETL is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
 #
-# You should have received a copy of the GNU Affero General Public License along with BBMRI-FP-ETL. If not, see <https://www.gnu.org/licenses/>.
+# You should have received a copy of the GNU Affero General Public License
+# along with BBMRI-FP-ETL. If not, see <https://www.gnu.org/licenses/>.
 
 from abc import ABC, abstractmethod
+from typing import Iterable
+from . models import Aggregate, Case
 
 
 class AbstractSource(ABC):
 
     @abstractmethod
-    def get_cases_data(self):
+    def get_cases_data(self) -> Iterable[Case]:
         """
         This method should return the data in the Biobank represented as Case
         Each Case contains data about the donor, his/her samples and events related to the donor and to the samples
         (e.g., Diagnosis Event, Sampling Event, etc...)
-        :return: a list of Case
+        :return: Iterable[Case]
         """
 
-    def get_biobanks_data(self):
+    @abstractmethod
+    def get_biobanks_data(self) -> Iterable[Aggregate]:
         """
         This method should return data about Biobanks and Collections
-        :return:
+        :return:  Iterable[Aggregate]
         """
-
-

--- a/examples/example_source.py
+++ b/examples/example_source.py
@@ -11,6 +11,7 @@
 import os
 from collections import namedtuple
 from datetime import datetime, date
+from typing import Iterable
 
 from bbmri_fp_etl.converter import Converter
 from bbmri_fp_etl.destinations.fhir import FHIRDest
@@ -74,7 +75,10 @@ class ExampleSource(AbstractSource):
     It is not intended to be computationally efficient
     """
 
-    def get_cases_data(self):
+    def get_biobanks_data(self):
+        raise NotImplementedError()
+
+    def get_cases_data(self) -> Iterable[Case]:
         cases = []
         for p in PATIENTS:
             donor = Donor(


### PR DESCRIPTION
Fix a missing `@abstractmethod` decorator on `AbstractSource.get_biobanks_data`.  This PR also adds return typing information on the `AbstractSource` methods.

Also, it adds a check for `None` on a use of the optional `Aggregate.contact` member.